### PR TITLE
appIcons: Add 'Focus, minimize or show previews'

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -86,6 +86,7 @@
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
                           <item translatable="yes">Focus or show previews</item>
+                          <item translatable="yes">Focus, minimize or show previews</item>
                           <item translatable="yes">Quit</item>
                         </items>
                       </object>
@@ -159,6 +160,7 @@
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
                           <item translatable="yes">Focus or show previews</item>
+                          <item translatable="yes">Focus, minimize or show previews</item>
                           <item translatable="yes">Quit</item>
                         </items>
                       </object>
@@ -232,6 +234,7 @@
                           <item translatable="yes">Show window previews</item>
                           <item translatable="yes">Minimize or show previews</item>
                           <item translatable="yes">Focus or show previews</item>
+                          <item translatable="yes">Focus, minimize or show previews</item>
                           <item translatable="yes">Quit</item>
                         </items>
                       </object>
@@ -1677,6 +1680,7 @@
                                   <item translatable="yes">Show window previews</item>
                                   <item translatable="yes">Minimize or show previews</item>
                                   <item translatable="yes">Focus or show previews</item>
+                                  <item translatable="yes">Focus, minimize or show previews</item>
                                 </items>
                               </object>
                               <packing>

--- a/appIcons.js
+++ b/appIcons.js
@@ -45,7 +45,8 @@ const clickAction = {
     PREVIEWS: 5,
     MINIMIZE_OR_PREVIEWS: 6,
     FOCUS_OR_PREVIEWS: 7,
-    QUIT: 8,
+    FOCUS_MINIMIZE_OR_PREVIEWS: 8,
+    QUIT: 9
 };
 
 const scrollAction = {
@@ -455,6 +456,19 @@ class MyAppIcon extends Dash.DashIcon {
                 if (this.app == focusedApp &&
                     (windows.length > 1 || modifiers || button != 1)) {
                     this._windowPreviews();
+                } else {
+                    // Activate the first window
+                    let w = windows[0];
+                    Main.activateWindow(w);
+                }
+                break;
+
+            case clickAction.FOCUS_MINIMIZE_OR_PREVIEWS:
+                if (this.app == focusedApp) {
+                    if (windows.length > 1 || modifiers || button != 1)
+                        this._windowPreviews();
+                    else if (!Main.overview.visible)
+                        this._minimizeWindow();
                 } else {
                     // Activate the first window
                     let w = windows[0];

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -9,7 +9,8 @@
     <value value='5' nick='previews'/>
     <value value='6' nick='minimize-or-previews'/>
     <value value='7' nick='focus-or-previews'/>
-    <value value='8' nick='quit'/>
+    <value value='8' nick='focus-minimize-or-previews'/>
+    <value value='9' nick='quit'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-dock.scrollAction'>
     <value value='0' nick='do-nothing'/>


### PR DESCRIPTION
This action mixes the behaviour of 'Focus or show previews' and
'Minimize or show previews', ie. it acts as follows:

- if app is not running, create new window
- if app is running but not focused, focus (first) window
- if app is running and focused:
  - if app has multiple windows, show previews
  - otherwise, minimize window